### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Thanks to :
 * [Chardin-js](https://github.com/heelhook/chardin.js) by grevory
 * [Bootstrap Growl](https://github.com/ifightcrime/bootstrap-growl) by ifightcrime
 
-#TO BE DONE :-
+# TO BE DONE :-
 
 - [x] Drag and Drop functionality
 - [] Nested Grids


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
